### PR TITLE
Filter out the Redis GET command and retain spans with a duration exceeding 1s

### DIFF
--- a/opentelemetry-java-instrumentation/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/RedisCommandUtil.java
+++ b/opentelemetry-java-instrumentation/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/RedisCommandUtil.java
@@ -6,15 +6,26 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@SuppressWarnings("SystemOut")
 public final class RedisCommandUtil {
-    // 不进行span导出的命令
+    // don't perform the span export command
     public static final String REDIS_EXCLUDE_COMMAND = "PING|AUTH";
 
-    //The operation quantity of these commands is too large, it needs to be skipped.
-    private static final Set<String> SKIP_END_NAME = Stream.of("hget", "mget", "mset", "hmget", "hgetall").collect(Collectors.toSet());
+    // The operation quantity of these commands is too large, it needs to be skipped.
+    private static final Set<String> SKIP_END_NAME = Stream.of("hget", "mget", "mset", "hmget", "hgetall", "get").collect(Collectors.toSet());
 
-    //If it's in skipName and there are no errors, skip it directly.(issue #16)
-    public static boolean skipEnd(String operationName, @Nullable Throwable error) {
-        return (null != operationName) && (SKIP_END_NAME.contains(operationName.toLowerCase()) && (null == error));
+    // Retain spans that exceed this duration threshold, unit: ms.
+    private static final int DURATION_THRESHOLD = 1000;
+
+    // If it's in skipName and there are no errors, skip it directly.(issue #16)
+    public static boolean skipEnd(String operationName, @Nullable Throwable error, long startTime) {
+        return (null != operationName) && (SKIP_END_NAME.contains(operationName.toLowerCase()) && (null == error) && (redisDuration(startTime) < DURATION_THRESHOLD));
+    }
+
+    private static long redisDuration(long startTime){
+        System.out.println("start time is : "+startTime);
+        long l = System.currentTimeMillis() - startTime;
+        System.out.println("duration is : "+l);
+        return l;
     }
 }

--- a/opentelemetry-java-instrumentation/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisConnectionInstrumentation.java
+++ b/opentelemetry-java-instrumentation/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisConnectionInstrumentation.java
@@ -61,7 +61,9 @@ public class JedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Argument(0) Protocol.Command command,
         @Advice.Local("otelJedisRequest") JedisRequest request,
         @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Local("startTime") long startTime) {
+      startTime = System.currentTimeMillis();
       if(RedisCommandUtil.REDIS_EXCLUDE_COMMAND.contains(command.name())){
         return;
       }
@@ -81,14 +83,15 @@ public class JedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Argument(0) Protocol.Command command,
         @Advice.Local("otelJedisRequest") JedisRequest request,
         @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Local("startTime") long startTime) {
       if (scope == null) {
         return;
       }
 
       scope.close();
 
-      if (RedisCommandUtil.skipEnd(command.name(), throwable)) {
+      if (RedisCommandUtil.skipEnd(command.name(), throwable, startTime)) {
         return;
       }
       instrumenter().end(context, request, null, throwable);
@@ -105,7 +108,9 @@ public class JedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Argument(1) byte[][] args,
         @Advice.Local("otelJedisRequest") JedisRequest request,
         @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Local("startTime") long startTime) {
+      startTime = System.currentTimeMillis();
       if(RedisCommandUtil.REDIS_EXCLUDE_COMMAND.contains(command.name())){
         return;
       }
@@ -125,13 +130,14 @@ public class JedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Argument(0) Protocol.Command command,
         @Advice.Local("otelJedisRequest") JedisRequest request,
         @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Local("startTime") long startTime) {
       if (scope == null) {
         return;
       }
 
       scope.close();
-      if (RedisCommandUtil.skipEnd(command.name(), throwable)) {
+      if (RedisCommandUtil.skipEnd(command.name(), throwable, startTime)) {
         return;
       }
       instrumenter().end(context, request, null, throwable);

--- a/opentelemetry-java-instrumentation/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisConnectionInstrumentation.java
+++ b/opentelemetry-java-instrumentation/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisConnectionInstrumentation.java
@@ -56,7 +56,9 @@ public class JedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Argument(1) byte[][] args,
         @Advice.Local("otelJedisRequest") JedisRequest request,
         @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Local("startTime") long startTime) {
+      startTime = System.currentTimeMillis();
       if(RedisCommandUtil.REDIS_EXCLUDE_COMMAND.contains(new String(command.getRaw(), StandardCharsets.UTF_8))){
         return;
       }
@@ -75,14 +77,15 @@ public class JedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Thrown Throwable throwable,
         @Advice.Local("otelJedisRequest") JedisRequest request,
         @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Local("startTime") long startTime) {
       if (scope == null) {
         return;
       }
 
       scope.close();
       if(request != null){
-        if (RedisCommandUtil.skipEnd(new String(request.getCommand().getRaw(), StandardCharsets.UTF_8), throwable)) {
+        if (RedisCommandUtil.skipEnd(new String(request.getCommand().getRaw(), StandardCharsets.UTF_8), throwable, startTime)) {
           return;
         }
       }

--- a/opentelemetry-java-instrumentation/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/opentelemetry-java-instrumentation/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -16,7 +16,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.db.DbSpanNameExtractor;
 import io.opentelemetry.javaagent.instrumentation.api.instrumenter.PeerServiceAttributesExtractor;
 
 public final class LettuceSingletons {
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.javaagent.jedis-1.4";
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.javaagent.lettuce-4.0";
 
   private static final Instrumenter<RedisCommand<?, ?, ?>, Void> INSTRUMENTER;
 

--- a/opentelemetry-java-instrumentation/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/opentelemetry-java-instrumentation/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -16,7 +16,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.db.DbSpanNameExtractor;
 import io.opentelemetry.javaagent.instrumentation.api.instrumenter.PeerServiceAttributesExtractor;
 
 public final class LettuceSingletons {
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.javaagent.jedis-5.0";
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.javaagent.lettuce-5.0";
 
   private static final Instrumenter<RedisCommand<?, ?, ?>, Void> INSTRUMENTER;
 

--- a/opentelemetry-java-instrumentation/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/opentelemetry-java-instrumentation/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -184,6 +184,8 @@ final class OpenTelemetryTracing implements Tracing {
     @Nullable
     private String intranetErrorMessage;
 
+    private long startTime;
+
     OpenTelemetrySpan(SpanBuilder spanBuilder) {
       this.spanBuilder = spanBuilder;
     }
@@ -252,6 +254,7 @@ final class OpenTelemetryTracing implements Tracing {
     // Not called by Lettuce in 6.0+ (though we call it ourselves above).
     @Override
     public synchronized Tracer.Span start() {
+      startTime = System.currentTimeMillis();
       span = spanBuilder.startSpan();
       if (name != null) {
         span.updateName(name);
@@ -333,7 +336,7 @@ final class OpenTelemetryTracing implements Tracing {
 
     private void finish(Span span) {
       if (name != null) {
-        if (RedisCommandUtil.skipEnd(name, error)) {
+        if (RedisCommandUtil.skipEnd(name, error, startTime)) {
           return;
         }
         String statement = RedisCommandSanitizer.sanitize(name, splitArgs(args));


### PR DESCRIPTION
Filter out the Redis GET command and retain spans with a duration exceeding 1s. resolve #76 