### PR TITLE
fix: protoc add os.detected.classifier properties for MAC and windows

### DIFF
--- a/ozhera-demo-client/ozhera-demo-client-server/pom.xml
+++ b/ozhera-demo-client/ozhera-demo-client-server/pom.xml
@@ -14,6 +14,10 @@
     <properties>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <os-maven-plugin.version>1.6.1</os-maven-plugin.version>
+        <!-- MAC arm use this -->
+<!--        <os.detected.classifier>osx-x86_64</os.detected.classifier>-->
+        <!-- windows use this -->
+<!--        <os.detected.classifier>windows-x86_64</os.detected.classifier>-->
     </properties>
 
     <dependencies>
@@ -158,7 +162,6 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>${protobuf-maven-plugin.version}</version>
                 <configuration>
-                    <!-- 在MAC arm64芯片上编译时，需要将${os.detected.classifier}修改为osx-x86_64 -->
                     <protocArtifact>com.google.protobuf:protoc:3.24.0:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.58.0:exe:${os.detected.classifier}</pluginArtifact>

--- a/ozhera-demo-server/ozhera-demo-server-server/pom.xml
+++ b/ozhera-demo-server/ozhera-demo-server-server/pom.xml
@@ -14,6 +14,10 @@
     <properties>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <os-maven-plugin.version>1.6.1</os-maven-plugin.version>
+        <!-- MAC arm use this -->
+        <!--        <os.detected.classifier>osx-x86_64</os.detected.classifier>-->
+        <!-- windows use this -->
+        <!--        <os.detected.classifier>windows-x86_64</os.detected.classifier>-->
     </properties>
 
     <dependencies>


### PR DESCRIPTION
fix: protoc add os.detected.classifier properties for MAC and windows #327 