### PR TITLE
refactor: query logs by ID to reduce the limit of duplicate aliases

### DIFF
--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/common/validation/HeraConfigValid.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/common/validation/HeraConfigValid.java
@@ -16,7 +16,6 @@
 package com.xiaomi.mone.log.manager.common.validation;
 
 import com.xiaomi.mone.log.api.enums.MachineRegionEnum;
-import com.xiaomi.mone.log.api.enums.ProjectTypeEnum;
 import com.xiaomi.mone.log.manager.dao.MilogLogTailDao;
 import com.xiaomi.mone.log.manager.dao.MilogLogstoreDao;
 import com.xiaomi.mone.log.manager.model.bo.LogTailParam;
@@ -108,9 +107,9 @@ public class HeraConfigValid {
         return sb.toString();
     }
 
-    public boolean checkTailNameSame(String tailName, Long id, String machineRoom) {
+    public boolean checkTailNameSame(String tailName, Long id, String machineRoom, Long spaceId) {
         // Verify the log file with the same name
-        List<MilogLogTailDo> logtailDoList = milogLogtailDao.queryTailNameExists(tailName, machineRoom);
+        List<MilogLogTailDo> logtailDoList = milogLogtailDao.queryTailNameExists(tailName, machineRoom, spaceId);
         if (null == id) {
             return CollectionUtils.isNotEmpty(logtailDoList);
         } else {

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/dao/MilogLogTailDao.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/dao/MilogLogTailDao.java
@@ -279,10 +279,13 @@ public class MilogLogTailDao {
         return sql.getList(MilogLogTailDo.class);
     }
 
-    public List<MilogLogTailDo> queryTailNameExists(String tailName, String machineRoom) {
+    public List<MilogLogTailDo> queryTailNameExists(String tailName, String machineRoom, Long spaceId) {
         Sql sql = Sqls.queryEntity("SELECT la.* FROM milog_logstail la LEFT JOIN milog_logstore lt ON la.store_id = lt.id WHERE la.tail = @tailName AND lt.machine_room = @machineRoom");
         sql.params().set("tailName", tailName);
         sql.params().set("machineRoom", machineRoom);
+        if (null != spaceId) {
+            sql.params().set("store_id", spaceId);
+        }
         sql.setEntity(dao.getEntity(MilogLogTailDo.class));
         dao.execute(sql);
         return sql.getList(MilogLogTailDo.class);
@@ -376,5 +379,10 @@ public class MilogLogTailDao {
         return dao.query(MilogLogTailDo.class, Cnd.where("app_id", EQUAL_OPERATE, serviceId)
                 .and("app_type", EQUAL_OPERATE, typeCode)
                 .and("machine_type", EQUAL_OPERATE, MachineTypeEnum.PHYSICAL_MACHINE.getType()));
+    }
+
+    public List<MilogLogTailDo> queryByNames(Long storeId, List<String> nameList) {
+        Cnd cnd = Cnd.where("store_id", EQUAL_OPERATE, storeId).and("tail", "in", nameList);
+        return dao.query(MilogLogTailDo.class, cnd);
     }
 }

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/dao/MilogLogstoreDao.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/dao/MilogLogstoreDao.java
@@ -164,10 +164,13 @@ public class MilogLogstoreDao {
         return sql.getString();
     }
 
-    public boolean verifyExistByName(String logstoreName, Long id) {
+    public boolean verifyExistByName(String logstoreName, Long id, Long spaceId) {
         Cnd cnd = Cnd.where("logstoreName", EQUAL_OPERATE, logstoreName);
         if (null != id) {
             cnd.andNot("id", EQUAL_OPERATE, id);
+        }
+        if (null != spaceId) {
+            cnd.and("space_id", EQUAL_OPERATE, spaceId);
         }
         int count = dao.count(MilogLogStoreDO.class, cnd);
         return count > 0;

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/extension/common/CommonExtensionService.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/extension/common/CommonExtensionService.java
@@ -42,7 +42,7 @@ public interface CommonExtensionService {
 
     String getSortedKey(LogQuery logQuery, String sortedKey);
 
-    TermQueryBuilder multipleChooseBuilder(Long storeId, String chooseVal);
+    TermQueryBuilder multipleChooseBuilder(DefaultCommonExtensionService.QueryTypeEnum queryTypeEnum, Long storeId, String chooseVal);
 
     String queryDateHistogramField(Long storeId);
 

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/extension/common/DefaultCommonExtensionService.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/extension/common/DefaultCommonExtensionService.java
@@ -19,6 +19,7 @@ import com.xiaomi.mone.log.api.enums.MQSourceEnum;
 import com.xiaomi.mone.log.api.enums.MachineRegionEnum;
 import com.xiaomi.mone.log.manager.model.vo.LogQuery;
 import com.xiaomi.youpin.docean.anno.Service;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -63,7 +64,7 @@ public class DefaultCommonExtensionService implements CommonExtensionService {
     public BoolQueryBuilder commonRangeQuery(LogQuery logQuery) {
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
         boolQueryBuilder.filter(QueryBuilders.rangeQuery("timestamp").from(logQuery.getStartTime()).to(logQuery.getEndTime()));
-        boolQueryBuilder.filter(QueryBuilders.termQuery("logstore", logQuery.getLogstore()));
+        boolQueryBuilder.filter(QueryBuilders.termQuery("storeId", logQuery.getStoreId()));
         return boolQueryBuilder;
     }
 
@@ -73,7 +74,10 @@ public class DefaultCommonExtensionService implements CommonExtensionService {
     }
 
     @Override
-    public TermQueryBuilder multipleChooseBuilder(Long storeId, String chooseVal) {
+    public TermQueryBuilder multipleChooseBuilder(DefaultCommonExtensionService.QueryTypeEnum queryTypeEnum, Long storeId, String chooseVal) {
+        if (QueryTypeEnum.ID == queryTypeEnum) {
+            return QueryBuilders.termQuery("tailId", chooseVal);
+        }
         return QueryBuilders.termQuery("tail", chooseVal);
     }
 
@@ -90,5 +94,11 @@ public class DefaultCommonExtensionService implements CommonExtensionService {
     @Override
     public String getSpaceDataId(Long spaceId) {
         return getLogManagePrefix() + NAMESPACE_CONFIG_DATA_ID;
+    }
+
+    @Getter
+    public static enum QueryTypeEnum {
+        ID,
+        TEXT
     }
 }

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/impl/EsDataServiceImpl.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/impl/EsDataServiceImpl.java
@@ -397,7 +397,7 @@ public class EsDataServiceImpl implements EsDataService, LogDataService, EsDataB
     public Result<EsStatisticResult> EsStatistic(LogQuery logQuery) {
         try {
             EsStatisticResult result = new EsStatisticResult();
-            result.setName(constractEsStatisticRet(logQuery));
+            result.setName(constructEsStatisticRet(logQuery));
             MilogLogStoreDO logStore = logstoreDao.queryById(logQuery.getStoreId());
             if (logStore == null) {
                 return new Result<>(CommonError.UnknownError.getCode(), "not found logstore", null);
@@ -478,7 +478,7 @@ public class EsDataServiceImpl implements EsDataService, LogDataService, EsDataB
     }
 
 
-    public String constractEsStatisticRet(LogQuery logquery) {
+    public String constructEsStatisticRet(LogQuery logquery) {
         StringBuilder sb = new StringBuilder();
         if (!StringUtils.isEmpty(logquery.getLogstore())) {
             sb.append("logstore:").append(logquery.getLogstore()).append(";");

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/impl/LogStoreServiceImpl.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/impl/LogStoreServiceImpl.java
@@ -121,7 +121,7 @@ public class LogStoreServiceImpl extends BaseService implements LogStoreService 
         if (StringUtils.isNotEmpty(errorInfos)) {
             return Result.failParam(errorInfos);
         }
-        if (!cmd.getNameSameStatus() && logStoreDao.verifyExistByName(cmd.getLogstoreName(), null)) {
+        if (!cmd.getNameSameStatus() && logStoreDao.verifyExistByName(cmd.getLogstoreName(), null, cmd.getSpaceId())) {
             return new Result<>(CommonError.UnknownError.getCode(), "There is a store name with the same name", "");
         }
         List<MilogLogStoreDO> logStoreDOS = logStoreDao.queryBySpaceIdNamed(cmd.getSpaceId(), cmd.getLogstoreName());
@@ -226,7 +226,7 @@ public class LogStoreServiceImpl extends BaseService implements LogStoreService 
         if (StringUtils.isNotEmpty(errorInfos)) {
             return Result.failParam(errorInfos);
         }
-        if (logStoreDao.verifyExistByName(param.getLogstoreName(), param.getId())) {
+        if (logStoreDao.verifyExistByName(param.getLogstoreName(), param.getId(), param.getSpaceId())) {
             return new Result(CommonError.UnknownError.getCode(), "There is a store name with the same name", "");
         }
 

--- a/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/impl/LogTailServiceImpl.java
+++ b/ozhera-log/log-manager/src/main/java/com/xiaomi/mone/log/manager/service/impl/LogTailServiceImpl.java
@@ -207,7 +207,7 @@ public class LogTailServiceImpl extends BaseService implements LogTailService {
 
         String machineRoom = logStore.getMachineRoom();
         String tail = param.getTail();
-        if (heraConfigValid.checkTailNameSame(tail, null, machineRoom)) {
+        if (heraConfigValid.checkTailNameSame(tail, null, machineRoom, param.getSpaceId())) {
             return new Result<>(CommonError.ParamsError.getCode(), "The alias is duplicated, please confirm and submit");
         }
 
@@ -261,9 +261,9 @@ public class LogTailServiceImpl extends BaseService implements LogTailService {
         return mt;
     }
 
-    private boolean checkTailNameSame(String tailName, Long id, String machineRoom) {
+    private boolean checkTailNameSame(String tailName, Long id, String machineRoom, Long spaceId) {
         // Verify the log file with the same name
-        List<MilogLogTailDo> logtailDoList = milogLogtailDao.queryTailNameExists(tailName, machineRoom);
+        List<MilogLogTailDo> logtailDoList = milogLogtailDao.queryTailNameExists(tailName, machineRoom, spaceId);
         if (null == id) {
             return CollectionUtils.isNotEmpty(logtailDoList);
         } else {
@@ -404,7 +404,7 @@ public class LogTailServiceImpl extends BaseService implements LogTailService {
         String tail = param.getTail();
         Long id = param.getId();
         String machineRoom = logStoreDO.getMachineRoom();
-        if (checkTailNameSame(tail, id, machineRoom)) {
+        if (checkTailNameSame(tail, id, machineRoom, param.getSpaceId())) {
             return new Result<>(CommonError.ParamsError.getCode(), "The alias is duplicated, please confirm and submit");
         }
 


### PR DESCRIPTION
#333 
When querying logs, use ID queries and add a method of querying ID by name to reduce duplicate access to store and tail aliases