### PR TITLE
feat: add agent-server metrics

### DIFF
--- a/ozhera-log/log-agent-server/pom.xml
+++ b/ozhera-log/log-agent-server/pom.xml
@@ -136,6 +136,22 @@ http://www.apache.org/licenses/LICENSE-2.0
             <artifactId>hutool-all</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.ozhera</groupId>
+            <artifactId>ozhera-metrics-sdk</artifactId>
+            <version>2.2.6-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/ozhera-log/log-agent-server/src/main/java/org/apache/ozhera/log/server/metrics/AgentServerMetrics.java
+++ b/ozhera-log/log-agent-server/src/main/java/org/apache/ozhera/log/server/metrics/AgentServerMetrics.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ozhera.log.server.metrics;
+
+import org.apache.ozhera.metrics.api.Metrics;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Metrics utility for log-agent-server config publish paths.
+ * <p>
+ * All methods are static and wrapped in try/catch to avoid impacting the main flow.
+ */
+public final class AgentServerMetrics {
+
+    // Status values
+    public static final String STATUS_SUCCESS = "success";
+    public static final String STATUS_FAIL = "fail";
+    private static final String UNKNOWN = "unknown";
+
+    // Metric names
+    private static final String METRIC_STRATEGY_SEND_TOTAL = "agent_server_strategy_send_total";
+
+    // Label names
+    private static final String LABEL_STATUS = "status";
+    private static final String LABEL_AGENT_IP = "agent_ip";
+    private static final String LABEL_TAIL_ID = "tail_id";
+
+    private AgentServerMetrics() {
+    }
+
+    /**
+     * Increment strategy send total counter.
+     *
+     * @param status  {@link #STATUS_SUCCESS} or {@link #STATUS_FAIL}
+     * @param agentIp the target agent IP
+     * @param tailId  the logtail ID
+     */
+    public static void incrementStrategySendTotal(String status, String agentIp, String tailId) {
+        try {
+            Metrics.counter(METRIC_STRATEGY_SEND_TOTAL)
+                    .tag(LABEL_STATUS, normalize(status))
+                    .tag(LABEL_AGENT_IP, normalize(agentIp))
+                    .tag(LABEL_TAIL_ID, normalize(tailId))
+                    .inc();
+        } catch (Exception ignored) {
+            // Avoid impacting main flow if metrics fails
+        }
+    }
+
+    private static String normalize(String value) {
+        return StringUtils.isBlank(value) ? UNKNOWN : value;
+    }
+}

--- a/ozhera-log/log-agent-server/src/main/java/org/apache/ozhera/log/server/service/DefaultPublishConfigService.java
+++ b/ozhera-log/log-agent-server/src/main/java/org/apache/ozhera/log/server/service/DefaultPublishConfigService.java
@@ -28,9 +28,12 @@ import com.xiaomi.youpin.docean.plugin.dubbo.anno.Service;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.ozhera.log.api.model.meta.AppLogMeta;
 import org.apache.ozhera.log.api.model.meta.LogCollectMeta;
+import org.apache.ozhera.log.api.model.meta.LogPattern;
 import org.apache.ozhera.log.api.model.vo.LogCmd;
 import org.apache.ozhera.log.api.service.PublishConfigService;
+import org.apache.ozhera.log.server.metrics.AgentServerMetrics;
 import org.apache.ozhera.log.utils.NetUtil;
 
 import javax.annotation.Resource;
@@ -106,6 +109,7 @@ public class DefaultPublishConfigService implements PublishConfigService {
     }
 
     private void doSendConfig(String agentIp, LogCollectMeta meta) {
+        List<String> tailIds = extractTailIds(meta);
         int count = 1;
         while (count < 3) {
             Map<String, AgentChannel> logAgentMap = getAgentChannelMap();
@@ -127,6 +131,10 @@ public class DefaultPublishConfigService implements PublishConfigService {
                     String response = new String(res.getBody());
                     log.info("The configuration is send successfully---->{},duration：{}s,agentIp:{}", response, started.elapsed().getSeconds(), agentCurrentIp);
                     if (Objects.equals(response, "ok")) {
+                        for (String tailId : tailIds) {
+                            AgentServerMetrics.incrementStrategySendTotal(
+                                    AgentServerMetrics.STATUS_SUCCESS, agentCurrentIp, tailId);
+                        }
                         break;
                     }
                 }
@@ -139,6 +147,12 @@ public class DefaultPublishConfigService implements PublishConfigService {
             } catch (final InterruptedException ignored) {
             }
             count++;
+        }
+        if (count >= 3) {
+            for (String tailId : tailIds) {
+                AgentServerMetrics.incrementStrategySendTotal(
+                        AgentServerMetrics.STATUS_FAIL, agentIp, tailId);
+            }
         }
     }
 
@@ -154,6 +168,27 @@ public class DefaultPublishConfigService implements PublishConfigService {
             log.info("The set of remote addresses of the connected agent machine is:{}", GSON.toJson(remoteAddress));
         }
         return remoteAddress;
+    }
+
+    private List<String> extractTailIds(LogCollectMeta meta) {
+        try {
+            List<String> tailIds = new ArrayList<>();
+            if (meta != null && CollectionUtils.isNotEmpty(meta.getAppLogMetaList())) {
+                for (AppLogMeta appLogMeta : meta.getAppLogMetaList()) {
+                    if (CollectionUtils.isNotEmpty(appLogMeta.getLogPatternList())) {
+                        for (LogPattern logPattern : appLogMeta.getLogPatternList()) {
+                            if (logPattern.getLogtailId() != null) {
+                                tailIds.add(String.valueOf(logPattern.getLogtailId()));
+                            }
+                        }
+                    }
+                }
+            }
+            return tailIds;
+        } catch (Exception e) {
+            log.warn("extractTailIds error", e);
+            return Collections.emptyList();
+        }
     }
 
     private Map<String, AgentChannel> getAgentChannelMap() {


### PR DESCRIPTION
## Summary
- Add metrics support for log-agent-server module
- Introduce `AgentServerMetrics` class for tracking agent server metrics
- Integrate metrics collection into `DefaultPublishConfigService`

## Test plan
- [ ] Verify agent-server starts successfully with new metrics dependencies
- [ ] Confirm metrics are correctly recorded during config publish operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)