### PR TITLE
fix: add wrapping directory to binary distribution

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -27,7 +27,8 @@
         <format>tar.gz</format>
         <format>dir</format>
     </formats>
-    <includeBaseDirectory>false</includeBaseDirectory>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>apache-ozhera-${project.version}-bin</baseDirectory>
 
     <fileSets>
         <fileSet>


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Adds a single wrapping directory to the binary distribution archive. The directory name matches the archive name: `apache-ozhera-${project.version}-bin`.

### Ⅱ. Does this pull request fix one issue?

Fixes #555

### Ⅲ. Why don't you add test cases (unit test/integration test)?

This only changes the Maven Assembly descriptor and does not affect runtime code. It was verified by building the complete 63-module reactor and inspecting the generated distribution archive.

### Ⅳ. Describe how to verify it

1. Build all module artifacts with `mvn -DskipTests package`.
2. Temporarily enable the existing `dist` execution by setting `skipAssembly` to `false` (verification only; not part of this PR).
3. Run `mvn -N -DskipTests org.apache.maven.plugins:maven-assembly-plugin:3.5.0:single@dist`.
4. Run `tar -tzf target/apache-ozhera-2.2.6-incubating-bin.tar.gz` and verify every entry is under `apache-ozhera-2.2.6-incubating-bin/`.

### Ⅴ. Special notes for reviews

The archive filename is unchanged. Only the internal archive layout gains a single root directory.