### PR TITLE
fix: correct typo "sucess" to "success" in AppMonitorController

### DIFF
--- a/ozhera-monitor/ozhera-monitor-server/src/main/java/org/apache/ozhera/monitor/controller/AppMonitorController.java
+++ b/ozhera-monitor/ozhera-monitor-server/src/main/java/org/apache/ozhera/monitor/controller/AppMonitorController.java
@@ -418,7 +418,7 @@ public class AppMonitorController {
 
         heraBaseInfoService.deleAppById(id);
 
-        return Result.success("sucess");
+        return Result.success("success");
     }
 
     @GetMapping("/mimonitor/appMembers")


### PR DESCRIPTION
## What this PR does

Fixes a misspelling in the success response message of `AppMonitorController`.

In `ozhera-monitor/ozhera-monitor-server/src/main/java/org/apache/ozhera/monitor/controller/AppMonitorController.java` (around line 421), the string `"sucess"` is corrected to `"success"`:

```java
-        return Result.success("sucess");
+        return Result.success("success");
```

## Why

`"sucess"` is a typo for `"success"`. This is a pure string literal change with no behavior or logic impact.

## Verification

- Single file, single line change; no business logic affected.
- Branch is based on the latest `apache/ozhera` master.

Fixes #671
